### PR TITLE
Change default database backend from SQLite3 to MySQL in settings.py as mentioned in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ``` 
  1. git clone https://github.com/gowthamand/django-crud-ajax-login-register-fileupload
 
- 2. Change settings.py MYSQL CONFIGURATIONS (name, user, password)
+ 2. Change settings.py MYSQL CONFIGURATIONS (name, user, password) [Make sure to install mysqlclient: pip install mysqlclient]
 
  3.  cd django-crud-ajax-login-register-fileupload
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -73,13 +73,18 @@ WSGI_APPLICATION = 'mysite.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
+# Use MySQL as the database backend
+# Make sure to install mysqlclient: pip install mysqlclient
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'your_db_name',         # Update this to your database name
+        'USER': 'your_db_user',         # Update this to your database user
+        'PASSWORD': 'your_db_password', # Update this to your database password
+        'HOST': 'localhost',            # Set to your MySQL host, usually 'localhost'
+        'PORT': '3306',                 
     }
 }
-
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
## Summary

This PR updates the default database configuration in `mysite/settings.py` to use MySQL instead of SQLite3. This change aligns the codebase with the project setup instructions, which reference MySQL.

## Changes

- Replaced the SQLite3 database configuration with a MySQL configuration block.
- Added placeholder values for `NAME`, `USER`, and `PASSWORD`.
- Included a comment reminding users to install the `mysqlclient` package for MySQL support.

## Motivation

The project’s instructions currently direct users to update MySQL settings, but the code was using SQLite3 by default. This update resolves that discrepancy and makes onboarding smoother for new users.

## Notes

- Users should ensure they have MySQL installed and update the database settings with their own credentials.
- Users should run `pip install mysqlclient` before running migrations.

Let me know if you would like any further changes!